### PR TITLE
invoke chrome with "exec"

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -10,5 +10,5 @@ if [ -n "$CHROME_OPTS" ]; then
 fi
 
 # Start Chrome
-exec sh -c "/usr/bin/google-chrome-unstable $CHROME_ARGS"
+exec sh -c "exec /usr/bin/google-chrome-unstable $CHROME_ARGS"
 


### PR DESCRIPTION
I think this should solve #2. I've seen a similar issue with another docker image. The issue is that not every implementation of `sh` uses `exec` by default and if it is not used, then signals do not get handled properly.

There might be an alternative solution that avoids the `sh -c` in this line, but I'm not a bash expert enough to know it by heart. 