### PR TITLE
Add --disable-dev-shm-usage flag

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,7 @@
 # Run the NSSDB updating utility in background
 import_cert.sh $HOME &
 
-CHROME_ARGS="--disable-gpu --headless --no-sandbox --remote-debugging-address=$DEBUG_ADDRESS --remote-debugging-port=$DEBUG_PORT --user-data-dir=/data"
+CHROME_ARGS="--disable-gpu --headless --no-sandbox --remote-debugging-address=$DEBUG_ADDRESS --remote-debugging-port=$DEBUG_PORT --user-data-dir=/data --disable-dev-shm-usage"
 
 if [ -n "$CHROME_OPTS" ]; then
   CHROME_ARGS="${CHROME_ARGS} ${CHROME_OPTS}"


### PR DESCRIPTION
For running in AWS ECS where you can't mount `/dev/shm`

See 

* https://github.com/GoogleChrome/puppeteer/issues/1834
* https://bugs.chromium.org/p/chromium/issues/detail?id=736452#c64